### PR TITLE
Revise DIF specifications registry in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@ Registry of DIF specifications showing current status, ratified versions, and ac
 | Specification | Status | Maintaining WG | Latest Ratified Version | Working Draft |
 |---------------|--------|----------------|-------------------------|---------------|
 | .well-known DID configuration | __DIF Ratified Specification__ | I&D WG | [v1.0.0](https://identity.foundation/well-known-did-configuration/resources/did-configuration/v1.0.0) | [current draft](https://identity.foundation/well-known-did-configuration/resources/did-configuration) |
-| CAWG Identity Assertions  | __DIF Ratified Specification__ | CA WG | [v1.1](https://cawg.io/identity/1.1/)  | [current draft](https://cawg.io/identity/) |
+| CAWG Identity Assertions  | __DIF Ratified Specification__ | CA WG | [v1.1](https://cawg.io/identity/1.1/)  | [1.2 draft](https://cawg.io/identity/1.2-draft/) |
+| CAWG Metadata Assertions  | __DIF Ratified Specification__ | CA WG | [v1.1](https://cawg.io/metadata/1.1/) | [1.2 draft](https://cawg.io/metadata/1.2-draft+media-identifiers/) |
+| CAWG Training and Data Mining Assertions  | __DIF Ratified Specification__ | CA WG | [v1.1](https://cawg.io/training-and-data-mining/1.1/)   | n/a |
 | CAWG Metadata Assertions  | __DIF Ratified Specification__ | CA WG | [v1.1](https://cawg.io/metadata/1.1/) | [current draft](https://cawg.io/metadata/) |
 | CAWG Training and Data Mining Assertions  | __DIF Ratified Specification__ | CA WG | [v1.1](https://cawg.io/training-and-data-mining/1.1/)   | [current draft](https://cawg.io/training-and-data-mining/) |
 | Confidential Storage | __Draft__  |SDS WG |   |  [current draft](https://identity.foundation/confidential-storage/) |


### PR DESCRIPTION
Update DIF spec tracker with unified table format

- Replace separate "finalized" and "non-finalized" tables with single table
- Update page description to clarify purpose and scope
- Standardize column naming: "Latest Ratified Version" and "Working Draft"
- Remove confusing "unofficial status" and redundant link columns

Addresses feedback from TSC discussion on spec tracker improvements.

Doesn't address inconsistency in versioning, e.g. v1.0.0 vs v1.0. Baby steps; we're making progress